### PR TITLE
Ecosystem Jobs board removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,6 @@
 
 - [Keep Starknet Strange](https://github.com/keep-starknet-strange) - Starkware Exploration team to kickstart exciting projects.
 - [OnlyDust](https://www.onlydust.xyz/) - Contribute to innovative projects.
-- [Ecosystem Jobs board](https://www.starknet.io/en/jobs) - Find a job with the best teams.
 - [Nethermind Jobs](https://www.nethermind.io/open-roles) - Join Nethermind's remote-first, close-knit crew of builders and tech professionals.
 - [Equilibrium Labs](https://equilibrium.co/join-us) - Explore the R&D company behind [Pathfinder](#node-implementations).
 


### PR DESCRIPTION
Fixes #104

Removing Ecosystem Jobs board  because it's not currently maintained
